### PR TITLE
Fixes error: Fix TypeError: Calling `.seed()`

### DIFF
--- a/faker_fdw/__init__.py
+++ b/faker_fdw/__init__.py
@@ -50,7 +50,7 @@ class FakerForeignDataWrapper(ForeignDataWrapper):
             self.seed = None
 
         faker = Faker(self.locale)
-        faker.seed(self.seed)
+        Faker.seed(self.seed)
 
         for column, definition in columns.items():
             log_to_postgres('column {} def {}'.format(column, type(definition.options)), DEBUG)


### PR DESCRIPTION
Fix error

TypeError: Calling `.seed()` on instances is deprecated. Use the class method `Faker.seed()` instead.

https://faker.readthedocs.io/en/master/fakerclass.html#upgrade-guide